### PR TITLE
Refactor to use nan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 *~
 .lock-wscript
 *.log
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
-  - 0.9
-  - 0.10
+  - "0.8"
+  - "0.10"
+  - "0.12"
+  - "iojs-v1.1.0"
 os:
   - linux
   - osx

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,8 @@
   "targets": [
     {
       "target_name": "posix",
-      "sources": [ "src/posix.cc" ]
+      "sources": [ "src/posix.cc" ],
+      "include_dirs": ["<!(node -e \"require('nan')\")"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "author" : "Mika Eloranta <mel@ohmu.fi>",
     "main" : "./lib/posix",
     "dependencies" : {
+      "nan": "~1.6.2"
     },
     "scripts" : {
         "test" : "make test"
     },
-    "engines" : { "node": ">= 0.6.0" }
+    "engines" : { "node": ">= 0.8.0" }
 }

--- a/test/unit/test-setsid.js
+++ b/test/unit/test-setsid.js
@@ -23,7 +23,6 @@ assert.throws(function () {
 }, /takes no arguments/);
 
 var sid = posix.setsid();
-console.log("setsid: " + sid);
 assert.equal(sid, process.pid);
 assert.equal(sid, posix.getpgid(0));
 


### PR DESCRIPTION
I've refactored posix.cc to use [nan](https://github.com/rvagg/nan) as the v8 API has changed quite a bit in node 0.12.

The code now compiles and all tests pass (as non-privileged and super user) on node 0.8, 0.10, 0.12 and io.js 1.1.0.

nan doesn't support node 0.6 so I've removed this from the package.json and travis.yml files.

The only thing I couldn't translate cleanly was:

```cc
return ThrowException(ErrnoException(errno, "chroot: chdir: "));
```

From [the docs](https://github.com/rvagg/nan#api_nan_throw_error) it looks like you should be able to use:

```cc
return NanThrowError("chroot: chdir: ", errno);
```

..but that ends up with the JavaScript error property `code` being an int instead of a string (e.g. `2` vs `ENOENT`) which is less useful so I left it as the node `ErrnoException` call.  I'll open an issue with nan to try to get some clarity.

The only other thing was that in test-setsid.js writing anything to stdout after the first successful setsid call caused the test to fail on node 0.12 and io.js.  I removed that line and the test passes.  This would ordinarily ring alarm bells, but is exposing setsid actually necessary?  Unless I've missed something you can achieve a similar effect (e.g. detaching a process from it's parent and letting it continue) by unRef()ing a child_process.